### PR TITLE
Automatic swagger docs

### DIFF
--- a/backend/drtrottoir/settings.py
+++ b/backend/drtrottoir/settings.py
@@ -44,6 +44,7 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "rest_framework",
     "django_filters",
+    "drf_yasg",
     "drtrottoir",
 ]
 

--- a/backend/drtrottoir/urls.py
+++ b/backend/drtrottoir/urls.py
@@ -15,7 +15,10 @@ Including another URLconf
 """
 from django.conf.urls.static import static
 from django.contrib import admin
-from django.urls import include, path
+from django.urls import include, path, re_path
+from drf_yasg import openapi
+from drf_yasg.views import get_schema_view
+from rest_framework import permissions
 from rest_framework.routers import DefaultRouter
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
@@ -36,6 +39,16 @@ from drtrottoir.views import (
     ScheduleDefinitionViewSet,
     ScheduleWorkEntryViewSet,
     UserViewSet,
+)
+
+schema_view = get_schema_view(
+    openapi.Info(
+        title="Dr. Trottoir Group 3",
+        default_version="v1",
+        description="",
+    ),
+    public=True,
+    permission_classes=[permissions.AllowAny],
 )
 
 router = DefaultRouter()
@@ -105,6 +118,19 @@ urlpatterns = [
         settings.BASE_PATH + "auth/token/refresh/",
         TokenRefreshView.as_view(),
         name="token_refresh",
+    ),
+    re_path(
+        r"^swagger(?P<format>\.json|\.yaml)$",
+        schema_view.without_ui(cache_timeout=0),
+        name="schema-json",
+    ),
+    re_path(
+        r"^swagger/$",
+        schema_view.with_ui("swagger", cache_timeout=0),
+        name="schema-swagger-ui",
+    ),
+    re_path(
+        r"^redoc/$", schema_view.with_ui("redoc", cache_timeout=0), name="schema-redoc"
     ),
 ]
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -19,5 +19,9 @@ plugins = ["mypy_django_plugin.main", "mypy_drf_plugin.main"]
 module = "rest_framework_simplejwt.*"
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+module = "drf_yasg.*"
+ignore_missing_imports = true
+
 [tool.django-stubs]
 django_settings_module = "drtrottoir.settings"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,3 +8,11 @@ Pillow==9.4.0
 uWSGI>=2.0.21,<2.1
 djangorestframework-simplejwt==5.2.2
 django-filter==23.1
+coreapi==2.3.3
+coreschema==0.0.4
+drf_yasg==1.21.5
+inflection==0.5.1
+itypes==1.2.0
+ruamel.yaml==0.17.21
+ruamel.yaml.clib==0.2.7
+uritemplate==4.1.1


### PR DESCRIPTION
Adds automatic generation and serving of Swagger OpenAPI docs using the `drf-yasg` module.

Note that a few errors are currently produced when viewing the schemas. This is is normal, and should be fixed once I rewrite the remaining ApiView's to ViewSet's.