### PR TITLE
Fix creating and updating users using API

### DIFF
--- a/backend/drtrottoir/serializers/user.py
+++ b/backend/drtrottoir/serializers/user.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from rest_framework import serializers
 
 from drtrottoir.models import Admin, Student, Syndicus, User
@@ -6,26 +8,55 @@ from drtrottoir.models import Admin, Student, Syndicus, User
 class AdminSerializer(serializers.ModelSerializer):
     class Meta:
         model = Admin
-        fields = "__all__"
+        fields: List[str] = []
+        read_only_fields = ["id", "user"]
 
 
 class StudentSerializer(serializers.ModelSerializer):
     class Meta:
         model = Student
-        fields = "__all__"
+        fields = ["location_group", "is_super_student"]
+        read_only_fields = ["id", "user"]
 
 
 class SyndicusSerializer(serializers.ModelSerializer):
     class Meta:
         model = Syndicus
-        fields = "__all__"
+        fields = ["buildings"]
+        read_only_fields = ["id", "user"]
 
 
 class UserSerializer(serializers.ModelSerializer):
-    student = StudentSerializer()
-    admin = AdminSerializer()
-    syndicus = SyndicusSerializer()
+    student = StudentSerializer(allow_null=True)
+    admin = AdminSerializer(allow_null=True)
+    syndicus = SyndicusSerializer(allow_null=True)
 
     class Meta:
         model = User
-        fields = ["id", "first_name", "last_name", "student", "admin", "syndicus"]
+        fields = [
+            "id",
+            "username",
+            "first_name",
+            "last_name",
+            "student",
+            "admin",
+            "syndicus",
+        ]
+
+    def create(self, validated_data):
+        student_data = validated_data.pop("student")
+        admin_data = validated_data.pop("admin")
+        syndicus_data = validated_data.pop("syndicus")
+
+        user = User.objects.create(**validated_data)
+
+        if student_data is not None:
+            Student.objects.create(user=user, **student_data)
+
+        if admin_data is not None:
+            Admin.objects.create(user=user, **admin_data)
+
+        if syndicus_data is not None:
+            Syndicus.objects.create(user=user, **syndicus_data)
+
+        return user

--- a/backend/drtrottoir/serializers/user.py
+++ b/backend/drtrottoir/serializers/user.py
@@ -42,6 +42,7 @@ class UserSerializer(serializers.ModelSerializer):
             "admin",
             "syndicus",
         ]
+        read_only_fields = ["id"]
 
     def create(self, validated_data):
         student_data = validated_data.pop("student")
@@ -60,3 +61,56 @@ class UserSerializer(serializers.ModelSerializer):
             Syndicus.objects.create(user=user, **syndicus_data)
 
         return user
+
+    @staticmethod
+    def update_one_on_one_field(instance, validated_data, field_name, field_model):
+        """
+        Utility function for the `update` method that updates a one-on-one
+        field's reverse relationship. It handles the following cases:
+        * New data is provided for a relationship that doesn't exist yet
+        * New data is provided for an existing relationship
+        * An existing relationship is set to null, meaning it should be removed
+        """
+        if field_name in validated_data:
+            field_data = validated_data.pop(field_name)
+            old_relation_exists = hasattr(instance, field_name)
+            new_relation_is_null = field_data is None
+
+            # Relation exists, but the new data is None -> remove relation
+            if old_relation_exists and new_relation_is_null:
+                getattr(instance, field_name).delete()
+                setattr(instance, field_name, None)
+
+            # Relation already exists, and data is provided -> update fields
+            elif old_relation_exists and not new_relation_is_null:
+                relation_instance = getattr(instance, field_name)
+
+                for field, value in field_data.items():
+                    setattr(relation_instance, field, value)
+
+                relation_instance.save(update_fields=field_data.keys())
+
+            # Relationship doesn't exist, but data is provided -> create
+            # relation
+            elif not new_relation_is_null:
+                field_model.objects.create(user=instance, **field_data)
+
+            # Final option is where both are null, meaning nothing has to be
+            # done
+
+    def update(self, instance, validated_data):
+        UserSerializer.update_one_on_one_field(
+            instance, validated_data, "student", Student
+        )
+        UserSerializer.update_one_on_one_field(instance, validated_data, "admin", Admin)
+        UserSerializer.update_one_on_one_field(
+            instance, validated_data, "syndicus", Syndicus
+        )
+
+        # Remaining data is what should be updated on the User instance itself
+        for field, value in validated_data.items():
+            setattr(instance, field, value)
+
+        instance.save(update_fields=validated_data.keys())
+
+        return instance

--- a/backend/drtrottoir/tests/test_user_views.py
+++ b/backend/drtrottoir/tests/test_user_views.py
@@ -1,7 +1,16 @@
+import json
+
 import pytest
 from rest_framework.test import APIClient
 
-from .dummy_data import insert_dummy_admin, insert_dummy_student, insert_dummy_syndicus
+from .dummy_data import (
+    insert_dummy_admin,
+    insert_dummy_building,
+    insert_dummy_location_group,
+    insert_dummy_student,
+    insert_dummy_syndicus,
+    insert_dummy_user,
+)
 
 
 def insert_dummy_users():
@@ -190,3 +199,211 @@ def test_users_me_failure():
     res = client.get("/users/me/")
 
     assert res.status_code == 403
+
+
+def _test_user_create(data, user=None):
+    client = APIClient()
+
+    if user is not None:
+        client.force_login(user)
+
+    return client.post("/users/", json.dumps(data), content_type="application/json")
+
+
+@pytest.mark.django_db
+def test_user_create_forbidden():
+    res = _test_user_create({})
+    assert res.status_code == 403
+
+    student = insert_dummy_student(is_super_student=False)
+
+    res = _test_user_create({}, user=student.user)
+    assert res.status_code == 403
+
+    student = insert_dummy_student(
+        email="test-super@student.com", is_super_student=True
+    )
+
+    res = _test_user_create({}, user=student.user)
+    assert res.status_code == 400
+
+
+@pytest.mark.django_db
+def test_user_create_no_relations():
+    data = {
+        "username": "test-post@email.com",
+        "first_name": "Test",
+        "last_name": "User",
+        "admin": None,
+        "student": None,
+        "syndicus": None,
+    }
+
+    student = insert_dummy_student(is_super_student=True)
+
+    res = _test_user_create(data, user=student.user)
+    res.data.pop("id")
+    assert res.status_code == 201 and res.data == data
+
+
+@pytest.mark.django_db
+def test_user_create_admin():
+    data = {
+        "username": "test-post@email.com",
+        "first_name": "Test",
+        "last_name": "User",
+        "admin": {},
+        "student": None,
+        "syndicus": None,
+    }
+
+    student = insert_dummy_student(is_super_student=True)
+
+    res = _test_user_create(data, user=student.user)
+    res.data.pop("id")
+    assert res.status_code == 201 and res.data == data
+
+
+@pytest.mark.django_db
+def test_user_create_student():
+    lg = insert_dummy_location_group()
+
+    data = {
+        "username": "test-post@email.com",
+        "first_name": "Test",
+        "last_name": "User",
+        "admin": None,
+        "student": {"location_group": lg.id, "is_super_student": True},
+        "syndicus": None,
+    }
+
+    student = insert_dummy_student(is_super_student=True)
+
+    res = _test_user_create(data, user=student.user)
+    res.data.pop("id")
+    assert res.status_code == 201 and res.data == data
+
+
+@pytest.mark.django_db
+def test_user_create_syndicus():
+    b = insert_dummy_building()
+
+    data = {
+        "username": "test-post@email.com",
+        "first_name": "Test",
+        "last_name": "User",
+        "admin": None,
+        "student": None,
+        "syndicus": {"buildings": [b.id]},
+    }
+
+    student = insert_dummy_student(is_super_student=True)
+
+    res = _test_user_create(data, user=student.user)
+    res.data.pop("id")
+    assert res.status_code == 201 and res.data == data
+
+
+def _test_user_patch(user_to_patch, data, user=None):
+    client = APIClient()
+
+    if user is not None:
+        client.force_login(user)
+
+    return client.patch(
+        f"/users/{user_to_patch.id}/", json.dumps(data), content_type="application/json"
+    )
+
+
+@pytest.mark.django_db
+def test_user_patch_forbidden():
+    user_to_patch = insert_dummy_user()
+
+    res = _test_user_patch(user_to_patch, {})
+    assert res.status_code == 403
+
+    student = insert_dummy_student(is_super_student=False)
+
+    res = _test_user_patch(user_to_patch, {}, user=student.user)
+    assert res.status_code == 403
+
+    student = insert_dummy_student(
+        email="test-super@student.com", is_super_student=True
+    )
+
+    res = _test_user_patch(user_to_patch, {}, user=student.user)
+    assert res.status_code == 200
+
+
+@pytest.mark.django_db
+def test_user_patch_user_field():
+    user_to_patch = insert_dummy_user()
+    student = insert_dummy_student(is_super_student=True)
+
+    data = {"first_name": "new name"}
+
+    res = _test_user_patch(user_to_patch, data, user=student.user)
+
+    assert res.status_code == 200 and res.data["first_name"] == data["first_name"]
+
+
+@pytest.mark.django_db
+def test_user_patch_student_field():
+    student_to_patch = insert_dummy_student(is_super_student=False)
+    student = insert_dummy_student(
+        email="test-super@student.com", is_super_student=True
+    )
+
+    data = {"student": {"is_super_student": True}}
+
+    res = _test_user_patch(student_to_patch.user, data, user=student.user)
+
+    assert res.status_code == 200 and res.data["student"]["is_super_student"] is True
+
+
+@pytest.mark.django_db
+def test_user_patch_syndicus_buildings():
+    dummy_building_1 = insert_dummy_building()
+    dummy_building_2 = insert_dummy_building()
+
+    syndicus_to_patch = insert_dummy_syndicus()
+    student = insert_dummy_student(
+        email="test-super@student.com", is_super_student=True
+    )
+
+    data = {"syndicus": {"buildings": [dummy_building_1.id, dummy_building_2.id]}}
+
+    res = _test_user_patch(syndicus_to_patch.user, data, user=student.user)
+
+    assert res.status_code == 200 and sorted(
+        res.data["syndicus"]["buildings"]
+    ) == sorted([dummy_building_1.id, dummy_building_2.id])
+
+
+def _test_user_delete(user_to_delete, user=None):
+    client = APIClient()
+
+    if user is not None:
+        client.force_login(user)
+
+    return client.delete(f"/users/{user_to_delete.id}/")
+
+
+@pytest.mark.django_db
+def test_user_delete_forbidden():
+    user_to_delete = insert_dummy_user()
+
+    res = _test_user_delete(user_to_delete)
+    assert res.status_code == 403
+
+    student = insert_dummy_student(is_super_student=False)
+
+    res = _test_user_delete(user_to_delete, user=student.user)
+    assert res.status_code == 403
+
+    student = insert_dummy_student(
+        email="test-super@student.com", is_super_student=True
+    )
+
+    res = _test_user_delete(user_to_delete, user=student.user)
+    assert res.status_code == 204


### PR DESCRIPTION
This PR fixes the issue where users can't be created due to their relations requiring the user id, which doesn't exist yet. I've also fixed updating users.

I'll take this PR out of draft once I've written some API tests.

Closes #119 