### PR TITLE
Various backend issues

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -46,3 +46,7 @@ lint:
 .PHONY: test
 test:
 	'$(VENV)'/bin/pytest --cov --cov-config=.coveragerc drtrottoir/tests
+
+.PHONY: run
+run:
+	./venv/bin/python manage.py runserver -6

--- a/backend/drtrottoir/management/commands/mockdata.py
+++ b/backend/drtrottoir/management/commands/mockdata.py
@@ -138,7 +138,7 @@ class Command(BaseCommand):
 
         for i in range(10):
             lg = lgs[i % len(lgs)]
-            for version in range(1):
+            for version in range(1, 5):
                 sched = ScheduleDefinition(
                     name=f"schedule definition {i}", version=version, location_group=lg
                 )

--- a/backend/drtrottoir/models.py
+++ b/backend/drtrottoir/models.py
@@ -96,6 +96,10 @@ class ScheduleDefinitionBuilding(models.Model):
     )
     position = models.IntegerField()
 
+    # class Meta:
+    #     constraints = [models.UniqueConstraint(fields=['building',
+    #     'position'], name='unique_building_position')]
+
 
 class User(AbstractUser):
     """

--- a/backend/drtrottoir/serializers/building.py
+++ b/backend/drtrottoir/serializers/building.py
@@ -12,4 +12,4 @@ class BuildingSerializer(serializers.ModelSerializer):
 class ScheduleDefinitionBuildingSerializer(serializers.ModelSerializer):
     class Meta:
         model = ScheduleDefinitionBuilding
-        fields = "__all__"
+        fields = ["building", "position"]

--- a/backend/drtrottoir/tests/test_schedule_assignment.py
+++ b/backend/drtrottoir/tests/test_schedule_assignment.py
@@ -520,7 +520,7 @@ def test_schedule_assignment_delete_allowed_admin() -> None:
 
 
 @pytest.mark.django_db
-def test_schedule_assignment_delete_not_allowed_work_entries() -> None:
+def test_schedule_assignment_delete_not_allowed_with_existing_work_entries() -> None:
     dummy_student = insert_dummy_student("dummystudent@gmail.com")
     dummy_work_entry = insert_dummy_schedule_work_entry(dummy_student.user)
 

--- a/backend/drtrottoir/tests/test_schedule_assignment.py
+++ b/backend/drtrottoir/tests/test_schedule_assignment.py
@@ -9,6 +9,7 @@ from drtrottoir.tests.dummy_data import (
     insert_dummy_admin,
     insert_dummy_schedule_assignment,
     insert_dummy_schedule_definition,
+    insert_dummy_schedule_work_entry,
     insert_dummy_student,
     insert_dummy_syndicus,
     insert_dummy_user,
@@ -516,6 +517,22 @@ def test_schedule_assignment_delete_allowed_admin() -> None:
     )
 
     assert response_admin.status_code == 204
+
+
+@pytest.mark.django_db
+def test_schedule_assignment_delete_not_allowed_work_entries() -> None:
+    dummy_student = insert_dummy_student("dummystudent@gmail.com")
+    dummy_work_entry = insert_dummy_schedule_work_entry(dummy_student.user)
+
+    client = APIClient()
+    admin = insert_dummy_admin()
+
+    client.force_login(admin.user)
+    response_admin = client.delete(
+        f"/schedule_assignments/{dummy_work_entry.schedule_assignment.id}/"
+    )
+
+    assert response_admin.status_code == 400
 
 
 @pytest.mark.django_db

--- a/backend/drtrottoir/tests/test_schedule_definition_views.py
+++ b/backend/drtrottoir/tests/test_schedule_definition_views.py
@@ -2,10 +2,12 @@ import pytest
 from rest_framework.test import APIClient
 
 from .dummy_data import (
+    insert_dummy_admin,
     insert_dummy_schedule_assignment,
     insert_dummy_schedule_definition,
     insert_dummy_schedule_work_entry,
     insert_dummy_student,
+    insert_dummy_syndicus,
 )
 
 
@@ -213,10 +215,21 @@ def _test_schedule_definition_list_newest(user=None):
 
 
 @pytest.mark.django_db
-def test_schedule_definition_list_newest_success():
+def test_schedule_definition_list_newest_success_superstudent():
     student = insert_dummy_student(is_super_student=True)
 
     scheds, res = _test_schedule_definition_list_newest(student.user)
+
+    assert res.status_code == 200 and sorted([x["id"] for x in res.data]) == sorted(
+        [x.id for x in scheds]
+    )
+
+
+@pytest.mark.django_db
+def test_schedule_definition_list_newest_success_admin():
+    admin = insert_dummy_admin()
+
+    scheds, res = _test_schedule_definition_list_newest(admin.user)
 
     assert res.status_code == 200 and sorted([x["id"] for x in res.data]) == sorted(
         [x.id for x in scheds]
@@ -230,4 +243,8 @@ def test_schedule_definition_list_newest_fail():
 
     student = insert_dummy_student(is_super_student=False)
     _, res = _test_schedule_definition_list_newest(student.user)
+    assert res.status_code == 403
+
+    syndicus = insert_dummy_syndicus()
+    _, res = _test_schedule_definition_list_newest(syndicus.user)
     assert res.status_code == 403

--- a/backend/drtrottoir/tests/test_schedule_definition_views.py
+++ b/backend/drtrottoir/tests/test_schedule_definition_views.py
@@ -197,3 +197,37 @@ def test_schedule_definition_schedule_work_entries_fail():
     )
 
     assert res.status_code == 403
+
+
+def _test_schedule_definition_list_newest(user=None):
+    client = APIClient()
+
+    if user is not None:
+        client.force_login(user)
+
+    insert_dummy_schedule_definition(name="dummy 1", version=1)
+    schedule2 = insert_dummy_schedule_definition(name="dummy 1", version=2)
+    schedule3 = insert_dummy_schedule_definition(name="dummy 2", version=1)
+
+    return [schedule2, schedule3], client.get("/schedule_definitions/newest/")
+
+
+@pytest.mark.django_db
+def test_schedule_definition_list_newest_success():
+    student = insert_dummy_student(is_super_student=True)
+
+    scheds, res = _test_schedule_definition_list_newest(student.user)
+
+    assert res.status_code == 200 and sorted([x["id"] for x in res.data]) == sorted(
+        [x.id for x in scheds]
+    )
+
+
+@pytest.mark.django_db
+def test_schedule_definition_list_newest_fail():
+    _, res = _test_schedule_definition_list_newest()
+    assert res.status_code == 403
+
+    student = insert_dummy_student(is_super_student=False)
+    _, res = _test_schedule_definition_list_newest(student.user)
+    assert res.status_code == 403

--- a/backend/drtrottoir/tests/test_schedule_definition_views.py
+++ b/backend/drtrottoir/tests/test_schedule_definition_views.py
@@ -105,16 +105,6 @@ def _test_schedule_definition_buildings(assignment_user, user=None):
 
 
 @pytest.mark.django_db
-def test_schedule_definition_buildings_success():
-    student = insert_dummy_student()
-    assignment, res = _test_schedule_definition_buildings(student.user, student.user)
-
-    assert res.status_code == 200 and sorted(x["id"] for x in res.data) == sorted(
-        x.id for x in assignment.schedule_definition.buildings.all()
-    )
-
-
-@pytest.mark.django_db
 def test_schedule_definition_buildings_fail():
     assignment_student = insert_dummy_student(email="assignment@student.com")
 

--- a/backend/drtrottoir/views/schedule_assignment.py
+++ b/backend/drtrottoir/views/schedule_assignment.py
@@ -2,6 +2,7 @@ from typing import List
 
 from rest_framework import viewsets
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
 
 from drtrottoir.models import ScheduleAssignment
 from drtrottoir.permissions import (
@@ -67,3 +68,36 @@ class ScheduleAssignmentViewSet(PermissionsByActionMixin, viewsets.ModelViewSet)
             return ScheduleAssignment.objects.all()
 
         return ScheduleAssignment.objects.filter(user=self.request.user.id)
+
+    def update(self, *args, **kwargs):
+        schedule_assignment = self.get_object()
+
+        if schedule_assignment.work_entries.count() > 0:
+            return Response(
+                "You cannot edit schedule assignments with related work entries.",
+                status=400,
+            )
+
+        return super().update(*args, **kwargs)
+
+    def partial_update(self, *args, **kwargs):
+        schedule_assignment = self.get_object()
+
+        if schedule_assignment.work_entries.count() > 0:
+            return Response(
+                "You cannot edit schedule assignments with related work entries.",
+                status=400,
+            )
+
+        return super().partial_update(*args, **kwargs)
+
+    def destroy(self, *args, **kwargs):
+        schedule_assignment = self.get_object()
+
+        if schedule_assignment.work_entries.count() > 0:
+            return Response(
+                "You cannot schedule assignments with related work entries.",
+                status=400,
+            )
+
+        return super().destroy(*args, **kwargs)

--- a/backend/drtrottoir/views/schedule_definition.py
+++ b/backend/drtrottoir/views/schedule_definition.py
@@ -2,14 +2,18 @@ from rest_framework import mixins, permissions, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
-from drtrottoir.models import ScheduleDefinition, ScheduleWorkEntry
+from drtrottoir.models import (
+    ScheduleDefinition,
+    ScheduleDefinitionBuilding,
+    ScheduleWorkEntry,
+)
 from drtrottoir.permissions import (
     HasAssignmentForScheduleDefinition,
     IsSuperstudentOrAdmin,
 )
 from drtrottoir.serializers import (
-    BuildingSerializer,
     ScheduleAssignmentSerializer,
+    ScheduleDefinitionBuildingSerializer,
     ScheduleDefinitionSerializer,
     ScheduleWorkEntrySerializer,
 )
@@ -88,10 +92,39 @@ class ScheduleDefinitionViewSet(
     @action(detail=True)
     def buildings(self, request, pk=None):
         schedule_definition = self.get_object()
-        buildings = schedule_definition.buildings.all()
-        serializer = BuildingSerializer(buildings, many=True)
+        buildings = ScheduleDefinitionBuilding.objects.filter(
+            schedule_definition=schedule_definition
+        ).order_by("position")
+        serializer = ScheduleDefinitionBuildingSerializer(buildings, many=True)
 
         return Response(serializer.data)
+
+    # This counts as a different action than 'buildings', and therefore falls
+    # under the default permission_classes
+    @buildings.mapping.post
+    def set_buildings(self, request, pk=None):
+        serializer = ScheduleDefinitionBuildingSerializer(data=request.data, many=True)
+        serializer.is_valid(raise_exception=True)
+
+        schedule_definition = self.get_object()
+
+        # Remove old order & replace with new order
+        ScheduleDefinitionBuilding.objects.filter(
+            schedule_definition=schedule_definition
+        ).delete()
+        ScheduleDefinitionBuilding.objects.bulk_create(
+            (
+                ScheduleDefinitionBuilding(
+                    schedule_definition=schedule_definition,
+                    building=binding["building"],
+                    position=binding["position"],
+                )
+                for binding in serializer.validated_data
+            )
+        )
+
+        # Return ordered list of buildings
+        return self.buildings(request, pk)
 
     @action(detail=True)
     def schedule_assignments(self, request, pk=None):

--- a/backend/drtrottoir/views/schedule_definition.py
+++ b/backend/drtrottoir/views/schedule_definition.py
@@ -116,10 +116,10 @@ class ScheduleDefinitionViewSet(
             (
                 ScheduleDefinitionBuilding(
                     schedule_definition=schedule_definition,
-                    building=binding["building"],
-                    position=binding["position"],
+                    building=building["building"],
+                    position=building["position"],
                 )
-                for binding in serializer.validated_data
+                for building in serializer.validated_data
             )
         )
 

--- a/backend/drtrottoir/views/schedule_definition.py
+++ b/backend/drtrottoir/views/schedule_definition.py
@@ -143,3 +143,25 @@ class ScheduleDefinitionViewSet(
         serializer = ScheduleWorkEntrySerializer(schedule_work_entries, many=True)
 
         return Response(serializer.data)
+
+    @action(detail=False)
+    def newest(self, request):
+        # This proved to be an incredibly difficult query to perform using just
+        # ORM instructions, so I've written an SQL query instead
+        schedule_definitions = ScheduleDefinition.objects.raw(
+            """
+SELECT t1.*
+    FROM drtrottoir_scheduledefinition t1
+    INNER JOIN
+    (
+        SELECT name, MAX(version) AS max_version
+        FROM drtrottoir_scheduledefinition
+        GROUP BY name
+    ) t2
+        ON t1.name = t2.name AND t1.version = t2.max_version
+            """
+        )
+
+        serializer = ScheduleDefinitionSerializer(schedule_definitions, many=True)
+
+        return Response(serializer.data)


### PR DESCRIPTION
I'm creating this PR to handle a few minor backend issues that I'd like to fix.

* Allow retrieving list of buildings associated with schedule definition in order, and change it (closes #197, closes #190)
* `400` error message when attempting to modify schedule assignment with work entries (closes #188)
* `/schedule_definitions/newest/` endpoint for listing newest versions of schedule definitions (closes #187)