### PR TITLE
Change schedule definition buildings endpoint

### DIFF
--- a/backend/drtrottoir/tests/test_schedule_definition_views.py
+++ b/backend/drtrottoir/tests/test_schedule_definition_views.py
@@ -94,7 +94,7 @@ def test_schedule_definition_detail_fail():
     assert res.status_code == 403
 
 
-def _test_schedule_definition_buildings(assignment_user, user=None):
+def _test_schedule_definition_order(assignment_user, user=None):
     client = APIClient()
 
     if user is not None:
@@ -103,19 +103,19 @@ def _test_schedule_definition_buildings(assignment_user, user=None):
     assignment = insert_dummy_schedule_assignment(assignment_user)
     sched = assignment.schedule_definition
 
-    return assignment, client.get(f"/schedule_definitions/{sched.id}/buildings/")
+    return assignment, client.get(f"/schedule_definitions/{sched.id}/order/")
 
 
 @pytest.mark.django_db
-def test_schedule_definition_buildings_fail():
+def test_schedule_definition_order_fail():
     assignment_student = insert_dummy_student(email="assignment@student.com")
 
-    _, res = _test_schedule_definition_buildings(assignment_student.user)
+    _, res = _test_schedule_definition_order(assignment_student.user)
 
     assert res.status_code == 403
 
     student = insert_dummy_student()
-    _, res = _test_schedule_definition_buildings(assignment_student.user, student.user)
+    _, res = _test_schedule_definition_order(assignment_student.user, student.user)
 
     assert res.status_code == 403
 

--- a/backend/drtrottoir/views/schedule_definition.py
+++ b/backend/drtrottoir/views/schedule_definition.py
@@ -12,6 +12,7 @@ from drtrottoir.permissions import (
     IsSuperstudentOrAdmin,
 )
 from drtrottoir.serializers import (
+    BuildingSerializer,
     ScheduleAssignmentSerializer,
     ScheduleDefinitionBuildingSerializer,
     ScheduleDefinitionSerializer,
@@ -87,10 +88,19 @@ class ScheduleDefinitionViewSet(
     permission_classes_by_action = {
         "retrieve": [permissions.IsAuthenticated, HasAssignmentForScheduleDefinition],
         "buildings": [permissions.IsAuthenticated, HasAssignmentForScheduleDefinition],
+        "order": [permissions.IsAuthenticated, HasAssignmentForScheduleDefinition],
     }
 
     @action(detail=True)
     def buildings(self, request, pk=None):
+        schedule_definition = self.get_object()
+        buildings = schedule_definition.buildings.all()
+        serializer = BuildingSerializer(buildings, many=True)
+
+        return Response(serializer.data)
+
+    @action(detail=True)
+    def order(self, request, pk=None):
         schedule_definition = self.get_object()
         buildings = ScheduleDefinitionBuilding.objects.filter(
             schedule_definition=schedule_definition
@@ -101,8 +111,8 @@ class ScheduleDefinitionViewSet(
 
     # This counts as a different action than 'buildings', and therefore falls
     # under the default permission_classes
-    @buildings.mapping.post
-    def set_buildings(self, request, pk=None):
+    @order.mapping.post
+    def set_order(self, request, pk=None):
         serializer = ScheduleDefinitionBuildingSerializer(data=request.data, many=True)
         serializer.is_valid(raise_exception=True)
 
@@ -124,7 +134,7 @@ class ScheduleDefinitionViewSet(
         )
 
         # Return ordered list of buildings
-        return self.buildings(request, pk)
+        return self.order(request, pk)
 
     @action(detail=True)
     def schedule_assignments(self, request, pk=None):


### PR DESCRIPTION
This PR updates the schedule definition viewset according to #243.

* `/schedule_definitions/:id/buildings/` now returns a list of actual buildings again
* `/schedule_definitions/:id/order/` returns the ordering list as previously done by `/buildings`, including POST support

Closes #243.