### PR TITLE
Jahidchetti/215 remove query filtering in frontend with backend query calls where supported

### DIFF
--- a/backend/drtrottoir/views/building.py
+++ b/backend/drtrottoir/views/building.py
@@ -133,7 +133,8 @@ class BuildingViewSet(
     }
 
     filterset_fields = {"is_active": ("exact",), "location_group": ("exact", "in")}
-    search_fields = ["address", "description"]
+    search_fields = ["address", "description", "name"]
+    ordering_fields = ["name", "address", "location_group__name"]
 
     queryset = Building.objects.all()
     serializer_class = BuildingSerializer

--- a/backend/drtrottoir/views/schedule_assignment.py
+++ b/backend/drtrottoir/views/schedule_assignment.py
@@ -58,10 +58,18 @@ class ScheduleAssignmentViewSet(PermissionsByActionMixin, viewsets.ModelViewSet)
         "user": ("exact", "in"),
         "schedule_definition__location_group": ("exact", "in"),
     }
-    search_fields: List[str] = ["schedule_definition__name", "user__username", "user__first_name", "user__last_name"]
+    search_fields: List[str] = [
+        "schedule_definition__name",
+        "user__username",
+        "user__first_name",
+        "user__last_name",
+    ]
 
-    ordering_fields: List[str] = ["schedule_definition__name", "schedule_definition__location_group__name",
-                                  "user__username"]
+    ordering_fields: List[str] = [
+        "schedule_definition__name",
+        "schedule_definition__location_group__name",
+        "user__username",
+    ]
 
     def get_queryset(self):
         """

--- a/backend/drtrottoir/views/schedule_assignment.py
+++ b/backend/drtrottoir/views/schedule_assignment.py
@@ -56,8 +56,12 @@ class ScheduleAssignmentViewSet(PermissionsByActionMixin, viewsets.ModelViewSet)
         "assigned_date": ("exact", "in", "gt", "lt"),
         "schedule_definition": ("exact", "in"),
         "user": ("exact", "in"),
+        "schedule_definition__location_group": ("exact", "in"),
     }
-    search_fields: List[str] = []
+    search_fields: List[str] = ["schedule_definition__name", "user__username", "user__first_name", "user__last_name"]
+
+    ordering_fields: List[str] = ["schedule_definition__name", "schedule_definition__location_group__name",
+                                  "user__username"]
 
     def get_queryset(self):
         """

--- a/backend/drtrottoir/views/schedule_definition.py
+++ b/backend/drtrottoir/views/schedule_definition.py
@@ -81,6 +81,7 @@ class ScheduleDefinitionViewSet(
         "buildings": ("exact",),
     }
     search_fields = ["name"]
+    ordering_fields = ["name", "location_group__name"]
 
     # This method allows more granular selection of permissions for any given
     # action
@@ -171,7 +172,6 @@ SELECT t1.*
         ON t1.name = t2.name AND t1.version = t2.max_version
             """
         )
-
         serializer = ScheduleDefinitionSerializer(schedule_definitions, many=True)
 
         return Response(serializer.data)

--- a/backend/drtrottoir/views/user.py
+++ b/backend/drtrottoir/views/user.py
@@ -50,6 +50,9 @@ class UserViewSet(ModelViewSet):
         "student__is_super_student": ("exact",),
         "student__location_group": ("exact", "in"),
         "syndicus__buildings": ("exact",),
+        "student__id": ("gt",),
+        "syndicus__id": ("gt",),
+        "admin__id": ("gt",),
     }
     search_fields = ["first_name", "last_name", "username"]
 

--- a/frontend/src/components/elements/ListViewElement/InsertFormElements/BuildingInsertFormComponent.tsx
+++ b/frontend/src/components/elements/ListViewElement/InsertFormElements/BuildingInsertFormComponent.tsx
@@ -34,6 +34,7 @@ export default function Form({setCanClose, canClose, setOpen, allRegions}: FormP
 
     const handleSubmitForm = () => {
         postBuilding(session, {
+            name: formName,
             address: formAddress,
             latitude: formCoordinate.lat,
             longitude: formCoordinate.lng,

--- a/frontend/src/components/elements/ListViewElement/InsertFormElements/BuildingInsertFormComponent.tsx
+++ b/frontend/src/components/elements/ListViewElement/InsertFormElements/BuildingInsertFormComponent.tsx
@@ -1,8 +1,18 @@
 import React from 'react';
 import {ClickAwayListener} from '@mui/base';
 import styles from '@/styles/listView.module.css';
-import {Box, Button, FormControl, IconButton, InputLabel, MenuItem, Select, TextField} from '@mui/material';
-import {LocationGroup} from '@/api/models';
+import {
+    Autocomplete,
+    Box,
+    Button,
+    FormControl,
+    IconButton,
+    InputLabel,
+    MenuItem,
+    Select,
+    TextField,
+} from '@mui/material';
+import {LocationGroup, User} from '@/api/models';
 import {postBuilding} from '@/api/api';
 import {useSession} from 'next-auth/react';
 import {LatLng} from 'leaflet';
@@ -10,20 +20,16 @@ import BuildingMapSelector from '@/components/elements/ListViewElement/InsertFor
 import axios from 'axios';
 import {PinDrop} from '@mui/icons-material';
 
-const dummySindici = [
-    {name: 'Jan Tomas'},
-    {name: 'Peter Selie'},
-    {name: 'Wily Willson'},
-];
 
 type FormProps = {
     setCanClose: React.Dispatch<React.SetStateAction<boolean>>,
     canClose: boolean,
     setOpen: React.Dispatch<React.SetStateAction<boolean>>,
     allRegions: LocationGroup[],
+    allSyndici: User[],
 }
 
-export default function Form({setCanClose, canClose, setOpen, allRegions}: FormProps) {
+export default function Form({setCanClose, canClose, setOpen, allRegions, allSyndici}: FormProps) {
     const {data: session} = useSession();
 
     const handleClose = () => {
@@ -51,8 +57,9 @@ export default function Form({setCanClose, canClose, setOpen, allRegions}: FormP
     const [formAddress, setFormAddress] = React.useState('');
     const [formCoordinate, setFormCoordinate] = React.useState<LatLng>(new LatLng(51.1576985, 4.0807745));
     const [formRegion, setFormRegion] = React.useState<LocationGroup>();
-    const [formSyndic, setFormSyndic] = React.useState('');
+    const [formSyndic, setFormSyndic] = React.useState<User>();
     const [formDescription, setFormDescription] = React.useState('');
+
 
     React.useEffect(() => {
         setCanClose(true);
@@ -83,7 +90,7 @@ export default function Form({setCanClose, canClose, setOpen, allRegions}: FormP
                             >
                                 {allRegions.map((option) => (
                                     <MenuItem id='menuitem' key={option.id} value={option.id}
-                                              style={{wordBreak: 'break-all', whiteSpace: 'normal'}}>
+                                        style={{wordBreak: 'break-all', whiteSpace: 'normal'}}>
                                         {option.name}
                                     </MenuItem>
                                 ))}
@@ -124,25 +131,26 @@ export default function Form({setCanClose, canClose, setOpen, allRegions}: FormP
                                 onChange={(e) => setFormDescription(e.target.value as string)}
                             />
                         </div>
-                        <FormControl sx={{minWidth: 200}}>
-                            <InputLabel>syndicus</InputLabel>
-                            <Select
+                        <FormControl sx={{m: 1, width: 200}}>
+                            <Autocomplete
+                                id="tags-standard"
+                                options={allSyndici}
+                                getOptionLabel={(option) => option.first_name[0] + '. ' + option.last_name}
                                 value={formSyndic}
-                                onChange={(e) => setFormSyndic(e.target.value as string)}
-                                label='syndicus'
-                                defaultValue=''
-                                MenuProps={{disablePortal: true}}
-                            >
-                                <MenuItem value=''>
-                                    <em>geen</em>
-                                </MenuItem>
-                                {dummySindici.map((option) => (
-                                    <MenuItem id='menuitem' key={option.name} value={option.name}
-                                              style={{wordBreak: 'break-all', whiteSpace: 'normal'}}>
-                                        {option.name}
-                                    </MenuItem>
-                                ))}
-                            </Select>
+                                onChange={(e, v) => {
+                                    if (v !== null) {
+                                        setFormSyndic(v);
+                                    }
+                                }}
+                                renderInput={(params) => (
+                                    <TextField
+                                        {...params}
+                                        variant="standard"
+                                        label="syndicus"
+                                        placeholder="syndicus"
+                                    />
+                                )}
+                            />
                         </FormControl>
                     </div>
                     <div className={styles.formButtons}>
@@ -150,7 +158,7 @@ export default function Form({setCanClose, canClose, setOpen, allRegions}: FormP
                             Cancel
                         </Button>
                         <Button variant='contained' className={styles.button} onClick={handleSubmitForm}
-                                style={{backgroundColor: '#E6E600'}}>
+                            style={{backgroundColor: '#E6E600'}}>
                             Submit
                         </Button>
                     </div>

--- a/frontend/src/components/elements/ListViewElement/InsertFormElements/RoutesInsertFormComponent.tsx
+++ b/frontend/src/components/elements/ListViewElement/InsertFormElements/RoutesInsertFormComponent.tsx
@@ -17,8 +17,12 @@ type FormProps = {
 export default function Form({setCanClose, canClose, setOpen, allRegions, allRoutes}: FormProps) {
     const {data: session} = useSession();
     const handleSubmitForm = () =>{
-        const prevVers = allRoutes.filter((e) => e.name === formName);
+        const prevVers = allRoutes.filter((e) => {
+            console.log(e.name + " - " + formName);
+            return (e.name === formName);
+        });
         let version = 1;
+        console.log(prevVers);
         if (prevVers.length > 0) {
             version = prevVers[prevVers.length-1].version + 1;
         }

--- a/frontend/src/components/elements/ListViewElement/InsertFormElements/RoutesInsertFormComponent.tsx
+++ b/frontend/src/components/elements/ListViewElement/InsertFormElements/RoutesInsertFormComponent.tsx
@@ -18,11 +18,9 @@ export default function Form({setCanClose, canClose, setOpen, allRegions, allRou
     const {data: session} = useSession();
     const handleSubmitForm = () =>{
         const prevVers = allRoutes.filter((e) => {
-            console.log(e.name + " - " + formName);
             return (e.name === formName);
         });
         let version = 1;
-        console.log(prevVers);
         if (prevVers.length > 0) {
             version = prevVers[prevVers.length-1].version + 1;
         }

--- a/frontend/src/components/elements/ListViewElement/TopBarElements/BuildingTopBarComponent.tsx
+++ b/frontend/src/components/elements/ListViewElement/TopBarElements/BuildingTopBarComponent.tsx
@@ -14,6 +14,7 @@ import SortIcon from '@mui/icons-material/Sort';
 import FilterAltIcon from '@mui/icons-material/FilterAlt';
 import AddIcon from '@mui/icons-material/Add';
 import Form from '../InsertFormElements/BuildingInsertFormComponent';
+import {Clear} from '@mui/icons-material';
 
 
 type TopBarProps = {
@@ -25,10 +26,11 @@ type TopBarProps = {
     amountOfResults: number,
     searchEntry: string,
     setSearchEntry: React.Dispatch<React.SetStateAction<string>>,
+    handleSearch: (b: boolean) => void,
 };
 
 export default function BuildingTopBarComponent({sorttype, setSorttype, selectedRegions, setRegion, allRegions,
-    searchEntry, setSearchEntry}:TopBarProps) {
+    searchEntry, setSearchEntry, handleSearch}:TopBarProps) {
     const AllesSelected = selectedRegions.length >= allRegions.length;
 
     const handleChangeRegion = (event: SelectChangeEvent<LocationGroup[]>) => {
@@ -62,7 +64,7 @@ export default function BuildingTopBarComponent({sorttype, setSorttype, selected
     return (
         <div className={styles.topBar}>
             <div className={styles.search_container}>
-                <IconButton type="button" sx={{p: '10px'}} aria-label="search">
+                <IconButton type="button" sx={{p: '10px'}} aria-label="search" onClick={() => handleSearch(false)}>
                     <SearchIcon />
                 </IconButton>
                 <InputBase
@@ -71,7 +73,20 @@ export default function BuildingTopBarComponent({sorttype, setSorttype, selected
                     fullWidth={true}
                     value={searchEntry}
                     onChange={(e) => setSearchEntry(e.target.value as string)}
+                    onKeyDown={(e) => {
+                        if (e.key == 'Enter') {
+                            handleSearch(false);
+                        }
+                    }}
                 />
+                <IconButton type="button" sx={{p: '10px'}} aria-label="clear" onClick={
+                    (e) => {
+                        setSearchEntry('');
+                        handleSearch(true);
+                    }
+                }>
+                    <Clear />
+                </IconButton>
             </div>
             <div className={styles.filters_container}>
                 <Button className={styles.filter_button}>

--- a/frontend/src/components/elements/ListViewElement/TopBarElements/BuildingTopBarComponent.tsx
+++ b/frontend/src/components/elements/ListViewElement/TopBarElements/BuildingTopBarComponent.tsx
@@ -115,7 +115,6 @@ export default function BuildingTopBarComponent({sorttype, setSorttype, selected
                         displayEmpty={true}
                         onChange={(e) => setSorttype(e.target.value as string)}
                         label="Sorteer op"
-                        renderValue={() => <p className={styles.collapse_text} style={{width: '40px'}}>{sorttype}</p>}
                     >
                         {Object.entries(sorttypes).map(([option, value]) => (
                             <MenuItem key={option} value={option}

--- a/frontend/src/components/elements/ListViewElement/TopBarElements/BuildingTopBarComponent.tsx
+++ b/frontend/src/components/elements/ListViewElement/TopBarElements/BuildingTopBarComponent.tsx
@@ -6,7 +6,7 @@ import {
     Select,
     SelectChangeEvent,
 } from '@mui/material';
-import {LocationGroup} from '@/api/models';
+import {LocationGroup, User} from '@/api/models';
 import React from 'react';
 import styles from './topBar.module.css';
 import SearchIcon from '@mui/icons-material/Search';
@@ -27,10 +27,11 @@ type TopBarProps = {
     searchEntry: string,
     setSearchEntry: React.Dispatch<React.SetStateAction<string>>,
     handleSearch: (b: boolean) => void,
+    allSyndici: User[],
 };
 
 export default function BuildingTopBarComponent({sorttype, setSorttype, selectedRegions, setRegion, allRegions,
-    searchEntry, setSearchEntry, handleSearch}:TopBarProps) {
+    searchEntry, setSearchEntry, handleSearch, allSyndici}:TopBarProps) {
     const AllesSelected = selectedRegions.length >= allRegions.length;
 
     const handleChangeRegion = (event: SelectChangeEvent<LocationGroup[]>) => {
@@ -183,7 +184,7 @@ export default function BuildingTopBarComponent({sorttype, setSorttype, selected
                 invisible={false}
             >
                 <Form setCanClose={setCanClose} canClose={canClose} setOpen={setOpen}
-                    allRegions={allRegions}></Form>
+                    allRegions={allRegions} allSyndici={allSyndici}></Form>
             </Backdrop>
         </div>
     );

--- a/frontend/src/components/elements/ListViewElement/TopBarElements/LiveRouteTopBarComponent.tsx
+++ b/frontend/src/components/elements/ListViewElement/TopBarElements/LiveRouteTopBarComponent.tsx
@@ -15,6 +15,7 @@ import {LocationGroup} from '@/api/models';
 import Button from '@mui/material/Button';
 import FilterAltIcon from '@mui/icons-material/FilterAlt';
 import SensorsRoundedIcon from '@mui/icons-material/SensorsRounded';
+import {Clear} from "@mui/icons-material";
 
 type TopBarProps = {
     sorttype: string,
@@ -25,11 +26,12 @@ type TopBarProps = {
     amountOfResults: number,
     searchEntry: string,
     setSearchEntry: React.Dispatch<React.SetStateAction<string>>,
+    handleSearch: (b: boolean) => void,
 }
 
 export default function LiveRouteTopBarComponent(
     {sorttype, setSorttype, selectedRegions, setSelectedRegions, allRegions,
-        searchEntry, setSearchEntry}:TopBarProps) {
+        searchEntry, setSearchEntry, handleSearch}:TopBarProps) {
     const AllesSelectedRegions = selectedRegions.length>=allRegions.length;
 
     const handleChangeRegion = (event: SelectChangeEvent<LocationGroup[]>) => {
@@ -65,7 +67,7 @@ export default function LiveRouteTopBarComponent(
     return (
         <div className={styles.topBar}>
             <div className={styles.search_container}>
-                <IconButton type="button" sx={{p: '10px'}} aria-label="search">
+                <IconButton type="button" sx={{p: '10px'}} aria-label="search" onClick={() => handleSearch(false)}>
                     <SearchIcon />
                 </IconButton>
                 <InputBase
@@ -74,7 +76,20 @@ export default function LiveRouteTopBarComponent(
                     fullWidth={true}
                     value={searchEntry}
                     onChange={(e) => setSearchEntry(e.target.value as string)}
+                    onKeyDown={(e) => {
+                        if (e.key == 'Enter') {
+                            handleSearch(false);
+                        }
+                    }}
                 />
+                <IconButton type="button" sx={{p: '10px'}} aria-label="clear" onClick={
+                    (e) => {
+                        setSearchEntry('');
+                        handleSearch(true);
+                    }
+                }>
+                    <Clear />
+                </IconButton>
             </div>
             <div className={styles.filters_container}>
                 <Button className={styles.filter_button}>

--- a/frontend/src/components/elements/ListViewElement/TopBarElements/LiveRouteTopBarComponent.tsx
+++ b/frontend/src/components/elements/ListViewElement/TopBarElements/LiveRouteTopBarComponent.tsx
@@ -15,7 +15,7 @@ import {LocationGroup} from '@/api/models';
 import Button from '@mui/material/Button';
 import FilterAltIcon from '@mui/icons-material/FilterAlt';
 import SensorsRoundedIcon from '@mui/icons-material/SensorsRounded';
-import {Clear} from "@mui/icons-material";
+import {Clear} from '@mui/icons-material';
 
 type TopBarProps = {
     sorttype: string,

--- a/frontend/src/components/elements/ListViewElement/TopBarElements/LiveRouteTopBarComponent.tsx
+++ b/frontend/src/components/elements/ListViewElement/TopBarElements/LiveRouteTopBarComponent.tsx
@@ -117,7 +117,6 @@ export default function LiveRouteTopBarComponent(
                         value={sorttype}
                         onChange={(e) => setSorttype(e.target.value as string)}
                         label="Sorteer op"
-                        renderValue={() => <p className={styles.collapse_text} style={{width: '40px'}}>{sorttype}</p>}
                     >
                         {Object.entries(sorttypes).map(([option, value]) => (
                             <MenuItem key={option} value={option}

--- a/frontend/src/components/elements/ListViewElement/TopBarElements/RouteTopBarComponent.tsx
+++ b/frontend/src/components/elements/ListViewElement/TopBarElements/RouteTopBarComponent.tsx
@@ -202,9 +202,9 @@ export default function RouteTopBarComponent({sorttype, setSorttype, selectedReg
                         value={selectedActive}
                         onChange={(e) => setSelectedActive(e.target.value as string)}
                         label="Type"
-                        renderValue={() => <p className={styles.collapse_text} style={{width: '40px'}}>
-                            {selectedActive.toString() === 'true' ? 'Actief' : 'Alle'}
-                        </p>}
+                        // renderValue={() => <p className={styles.collapse_text} style={{width: '40px'}}>
+                        //     {selectedActive.toString() === 'true' ? 'Actief' : 'Alle'}
+                        // </p>}
                     >
                         {Object.entries(newestOnly).map(([option, value]) => (
                             <MenuItem key={option} value={option}

--- a/frontend/src/components/elements/ListViewElement/TopBarElements/RouteTopBarComponent.tsx
+++ b/frontend/src/components/elements/ListViewElement/TopBarElements/RouteTopBarComponent.tsx
@@ -16,6 +16,7 @@ import {LocationGroup, ScheduleDefinition} from '@/api/models';
 import Form from '../InsertFormElements/RoutesInsertFormComponent';
 import FilterAltIcon from '@mui/icons-material/FilterAlt';
 import SensorsRoundedIcon from '@mui/icons-material/SensorsRounded';
+import {Clear} from '@mui/icons-material';
 
 type TopBarProps = {
     sorttype: string,
@@ -26,13 +27,14 @@ type TopBarProps = {
     amountOfResults: number,
     searchEntry: string,
     setSearchEntry: React.Dispatch<React.SetStateAction<string>>,
-    selectedActive: number | null,
-    setSelectedActive: React.Dispatch<React.SetStateAction<number | null>>,
+    selectedActive: string,
+    setSelectedActive: React.Dispatch<React.SetStateAction<string>>,
     allRoutes: ScheduleDefinition[],
+    handleSearch: (b: boolean) => void,
 };
 
 export default function RouteTopBarComponent({sorttype, setSorttype, selectedRegions, setRegion, allRegions,
-    searchEntry, setSearchEntry, selectedActive, setSelectedActive, allRoutes}:TopBarProps) {
+    searchEntry, setSearchEntry, selectedActive, setSelectedActive, allRoutes, handleSearch}:TopBarProps) {
     const AllesSelected = selectedRegions.length>=allRegions.length;
 
     const handleChangeRegion = (event: SelectChangeEvent<LocationGroup[]>) => {
@@ -46,15 +48,15 @@ export default function RouteTopBarComponent({sorttype, setSorttype, selectedReg
                 value );
     };
 
-    const activeTypes = {
-        false: 'niet actief',
-        true: 'actief',
+    const newestOnly = {
+        all: 'Alle',
+        newest: 'Actief',
     };
 
     const sorttypes = {
         name: 'naam',
         location_group__name: 'regio',
-        buildings: 'aantal gebouwen',
+        // buildings: 'aantal gebouwen',
     };
 
     const [open, setOpen] = React.useState(false);
@@ -69,7 +71,7 @@ export default function RouteTopBarComponent({sorttype, setSorttype, selectedReg
     return (
         <div className={styles.topBar}>
             <div className={styles.search_container}>
-                <IconButton type="button" sx={{p: '10px'}} aria-label="search">
+                <IconButton type="button" sx={{p: '10px'}} aria-label="search" onClick={() => handleSearch(false)}>
                     <SearchIcon />
                 </IconButton>
                 <InputBase
@@ -78,7 +80,20 @@ export default function RouteTopBarComponent({sorttype, setSorttype, selectedReg
                     fullWidth={true}
                     value={searchEntry}
                     onChange={(e) => setSearchEntry(e.target.value as string)}
+                    onKeyDown={(e) => {
+                        if (e.key == 'Enter') {
+                            handleSearch(false);
+                        }
+                    }}
                 />
+                <IconButton type="button" sx={{p: '10px'}} aria-label="clear" onClick={
+                    (e) => {
+                        setSearchEntry('');
+                        handleSearch(true);
+                    }
+                }>
+                    <Clear />
+                </IconButton>
             </div>
             <div className={styles.filters_container}>
                 <Button className={styles.filter_button}>
@@ -185,17 +200,13 @@ export default function RouteTopBarComponent({sorttype, setSorttype, selectedReg
                         }}
                         IconComponent={() => null}
                         value={selectedActive}
-                        onChange={(e) => setSelectedActive(e.target.value as number)}
+                        onChange={(e) => setSelectedActive(e.target.value as string)}
                         label="Type"
                         renderValue={() => <p className={styles.collapse_text} style={{width: '40px'}}>
-                            {selectedActive === null ? 'alles' :
-                                selectedActive.toString() === 'true' ? 'actief' : 'niet actief'}
+                            {selectedActive.toString() === 'true' ? 'Actief' : 'Alle'}
                         </p>}
                     >
-                        <MenuItem value={''}>
-                            <em>Alle</em>
-                        </MenuItem>
-                        {Object.entries(activeTypes).map(([option, value]) => (
+                        {Object.entries(newestOnly).map(([option, value]) => (
                             <MenuItem key={option} value={option}
                                 style={{wordBreak: 'break-all', whiteSpace: 'normal'}}>
                                 {value}

--- a/frontend/src/components/elements/ListViewElement/TopBarElements/UserTopBarComponent.tsx
+++ b/frontend/src/components/elements/ListViewElement/TopBarElements/UserTopBarComponent.tsx
@@ -13,7 +13,7 @@ import SortIcon from '@mui/icons-material/Sort';
 import AddIcon from '@mui/icons-material/Add';
 import {Building, LocationGroup} from '@/api/models';
 import Form from '../InsertFormElements/UserInsertFormComponent';
-import {Person} from '@mui/icons-material';
+import {Clear, Person} from '@mui/icons-material';
 import styles from './topBar.module.css';
 import FilterAltIcon from '@mui/icons-material/FilterAlt';
 
@@ -29,11 +29,12 @@ type TopBarProps = {
     selectedUserType: string,
     setSelectedUserType: React.Dispatch<React.SetStateAction<string>>,
     allBuildings: Building[],
+    handleSearch: (b: boolean) => void,
 }
 
 export default function UserTopBarComponent({sorttype, setSorttype, selectedRegions, setSelectedRegions, allRegions,
     searchEntry, setSearchEntry, selectedUserType, setSelectedUserType,
-    allBuildings}:TopBarProps) {
+    allBuildings, handleSearch}:TopBarProps) {
     const AllesSelectedRegions = selectedRegions.length>=allRegions.length;
 
     const handleChangeRegion = (event: SelectChangeEvent<LocationGroup[]>) => {
@@ -73,7 +74,7 @@ export default function UserTopBarComponent({sorttype, setSorttype, selectedRegi
     return (
         <div className={styles.topBar}>
             <div className={styles.search_container}>
-                <IconButton type="button" sx={{p: '10px'}} aria-label="search">
+                <IconButton type="button" sx={{p: '10px'}} aria-label="search" onClick={() => handleSearch(false)}>
                     <SearchIcon />
                 </IconButton>
                 <InputBase
@@ -82,7 +83,20 @@ export default function UserTopBarComponent({sorttype, setSorttype, selectedRegi
                     fullWidth={true}
                     value={searchEntry}
                     onChange={(e) => setSearchEntry(e.target.value as string)}
+                    onKeyDown={(e) => {
+                        if (e.key == 'Enter') {
+                            handleSearch(false);
+                        }
+                    }}
                 />
+                <IconButton type="button" sx={{p: '10px'}} aria-label="clear" onClick={
+                    (e) => {
+                        setSearchEntry('');
+                        handleSearch(true);
+                    }
+                }>
+                    <Clear />
+                </IconButton>
             </div>
             <div className={styles.filters_container}>
                 <Button className={styles.filter_button}>
@@ -225,7 +239,7 @@ export default function UserTopBarComponent({sorttype, setSorttype, selectedRegi
                 invisible={false}
             >
                 <Form setCanClose={setCanClose} canClose={canClose} setOpen={setOpen}
-                    allBuildings={allBuildings}></Form>
+                    allBuildings={allBuildings} allRegions={allRegions}></Form>
             </Backdrop>
         </div>
 

--- a/frontend/src/containers/BuildingsPage.tsx
+++ b/frontend/src/containers/BuildingsPage.tsx
@@ -5,8 +5,8 @@ import BuildingTopBarComponent from '@/components/elements/ListViewElement/TopBa
 import BuildingDetail from '@/components/elements/BuildingDetailElement/BuildingDetail';
 import React, {useEffect, useState} from 'react';
 import {useSession} from 'next-auth/react';
-import {getBuildingsList, getLocationGroupsList, useAuthenticatedApi} from '@/api/api';
-import {Building, LocationGroup} from '@/api/models';
+import {getBuildingsList, getLocationGroupsList, getUsersList, useAuthenticatedApi} from '@/api/api';
+import {Building, LocationGroup, User} from '@/api/models';
 import ApartmentRoundedIcon from '@mui/icons-material/ApartmentRounded';
 
 export default function BuildingsPage() {
@@ -19,13 +19,17 @@ export default function BuildingsPage() {
     const [searchEntry, setSearchEntry] = useState('');
     const [sorttype, setSorttype] = useState('name');
 
+    const [allSyndici, setAllSyndici] = useAuthenticatedApi<User[]>();
+
     useEffect(() => {
         getLocationGroupsList(session, setLocationGroups);
+        getUsersList(session, setAllSyndici, {syndicus__id__gt: 0});
     }, [session]);
 
     useEffect(() => {
         handleSearch(false);
     }, [session, selectedRegions, sorttype]);
+
 
     const handleSearch = (clear: boolean = false) => {
         let searchEntryOverwritten: string;
@@ -50,6 +54,7 @@ export default function BuildingsPage() {
         searchEntry={searchEntry}
         setSearchEntry={setSearchEntry}
         handleSearch={handleSearch}
+        allSyndici={allSyndici ? allSyndici.data: []}
     />;
 
 

--- a/frontend/src/containers/BuildingsPage.tsx
+++ b/frontend/src/containers/BuildingsPage.tsx
@@ -24,10 +24,7 @@ export default function BuildingsPage() {
     }, [session]);
 
     useEffect(() => {
-        getBuildingsList(session, setBuildings, {
-            ordering: sorttype,
-            search: searchEntry,
-            location_group__in: selectedRegions.map((e) => e.id).join(',')});
+        handleSearch(false);
     }, [session, selectedRegions, sorttype]);
 
     const handleSearch = (clear: boolean = false) => {

--- a/frontend/src/containers/BuildingsPage.tsx
+++ b/frontend/src/containers/BuildingsPage.tsx
@@ -24,9 +24,24 @@ export default function BuildingsPage() {
     }, [session]);
 
     useEffect(() => {
-        getBuildingsList(session, setBuildings, {location_group__in: selectedRegions.map((e) => e.id).join(',')});
-    }, [session, selectedRegions]);
+        getBuildingsList(session, setBuildings, {
+            ordering: sorttype,
+            search: searchEntry,
+            location_group__in: selectedRegions.map((e) => e.id).join(',')});
+    }, [session, selectedRegions, sorttype]);
 
+    const handleSearch = (clear: boolean = false) => {
+        let searchEntryOverwritten: string;
+        if (clear) {
+            searchEntryOverwritten = '';
+        } else {
+            searchEntryOverwritten = searchEntry;
+        }
+        getBuildingsList(session, setBuildings, {
+            ordering: sorttype,
+            search: searchEntryOverwritten,
+            location_group__in: selectedRegions.map((e) => e.id).join(',')});
+    };
 
     const topBar = <BuildingTopBarComponent
         sorttype={sorttype}
@@ -37,6 +52,7 @@ export default function BuildingsPage() {
         amountOfResults={buildings ? buildings.data.length : 0}
         searchEntry={searchEntry}
         setSearchEntry={setSearchEntry}
+        handleSearch={handleSearch}
     />;
 
 

--- a/frontend/src/containers/LiveRoutesPage.tsx
+++ b/frontend/src/containers/LiveRoutesPage.tsx
@@ -1,7 +1,8 @@
 import {useSession} from 'next-auth/react';
 import {
+    getLatestScheduleDefinitionsList,
     getLocationGroupsList, getScheduleAssignmentsList,
-    getScheduleDefinitionsList, getScheduleWorkEntriesList,
+    getScheduleWorkEntriesList,
     getUsersList,
     useAuthenticatedApi,
 } from '@/api/api';
@@ -31,7 +32,7 @@ export default function LiveRoutesPage() {
     const [selectedRegions, setSelectedRegions] = React.useState<LocationGroup[]>([]);
 
     useEffect(() => {
-        getScheduleDefinitionsList(session, setDefinitions, {is_active: true});
+        getLatestScheduleDefinitionsList(session, setDefinitions);
         getLocationGroupsList(session, setLocationGroups);
         // TODO: mockdata currently only has AR but would make more sense to be DE
         getScheduleWorkEntriesList(session, setWorkEntries, {entry_type: 'AR'});
@@ -39,6 +40,16 @@ export default function LiveRoutesPage() {
     }, [session]);
 
     useEffect(() => {
+        handleSearch(false);
+    }, [session, sorttype, selectedRegions]);
+
+    const handleSearch = (clear: boolean = false) => {
+        let searchEntryOverwritten: string;
+        if (clear) {
+            searchEntryOverwritten = '';
+        } else {
+            searchEntryOverwritten = searchEntry;
+        }
         let regionsFilter = '';
         selectedRegions.map((r) => {
             regionsFilter+=r.id + ',';
@@ -46,12 +57,12 @@ export default function LiveRoutesPage() {
         const todayDate = new Date();
         const today = todayDate.toISOString().split('T')[0];
         getScheduleAssignmentsList(session, setAssignments, {
+            search: searchEntryOverwritten,
             ordering: sorttype,
             schedule_definition__location_group__in: regionsFilter,
             assigned_date: today,
         });
-    }, [session, sorttype, selectedRegions]);
-
+    };
 
     useEffect(() => {
         const element = document.getElementById(styles['scroll_style']);
@@ -59,15 +70,6 @@ export default function LiveRoutesPage() {
             element.scrollTo({top: 0, behavior: 'smooth'});
         }
     }, [sorttype, selectedRegions]);
-
-    const filterLiveRoutes = (data: any[], search: string) => {
-        if (!search) {
-            return data;
-        } else {
-            search = search.toLowerCase();
-            return data.filter((d) => d.toLowerCase().replace(/ /g, '').includes(search));
-        }
-    };
 
 
     if (assignments && definitions && students && workEntries && locationGroups) {
@@ -84,8 +86,8 @@ export default function LiveRoutesPage() {
             };
         });
 
-        const filteredLiveRoutes = {
-            data: filterLiveRoutes(mappedAssignments, searchEntry),
+        const liveRoutesMapped = {
+            data: mappedAssignments,
             status: 200,
             success: true,
         };
@@ -96,15 +98,16 @@ export default function LiveRoutesPage() {
             selectedRegions={selectedRegions}
             setSelectedRegions={setSelectedRegions}
             allRegions={locationGroups ? locationGroups.data : []}
-            amountOfResults={filteredLiveRoutes ? filteredLiveRoutes.data.length : 0}
+            amountOfResults={liveRoutesMapped ? liveRoutesMapped.data.length : 0}
             searchEntry={searchEntry}
             setSearchEntry={setSearchEntry}
+            handleSearch={handleSearch}
         />;
 
         return (
             <>
                 <ListViewComponent
-                    listData={filteredLiveRoutes}
+                    listData={liveRoutesMapped}
                     setListData={setAssignments}
                     locationGroups={locationGroups}
                     selectedRegions={selectedRegions}

--- a/frontend/src/containers/UsersPage.tsx
+++ b/frontend/src/containers/UsersPage.tsx
@@ -1,4 +1,3 @@
-
 import ListViewComponent from '@/components/elements/ListViewElement/ListViewComponent';
 import UserElement from '@/components/elements/UserElement/UserElement';
 import {useSession} from 'next-auth/react';
@@ -32,6 +31,24 @@ export default function UsersPage() {
 
 
     useEffect(() => {
+        handleSearch(false);
+    }, [session, selectedRegions, sorttype, userType]);
+
+
+    useEffect(() => {
+        const element = document.getElementById(styles.scroll_style);
+        if (element !== null) {
+            element.scrollTo({top: 0, behavior: 'smooth'});
+        }
+    }, [sorttype, selectedRegions]);
+
+    const handleSearch = (clear: boolean = false) => {
+        let searchEntryOverwritten: string;
+        if (clear) {
+            searchEntryOverwritten = '';
+        } else {
+            searchEntryOverwritten = searchEntry;
+        }
         let regionsFilter = '';
         selectedRegions.map((r) => {
             regionsFilter+=r.id + ',';
@@ -50,29 +67,11 @@ export default function UsersPage() {
             syndicusFilter = '0';
         }
 
-        getUsersList(session, setUsers, {ordering: sorttype, student__location_group__in: regionsFilter,
+        getUsersList(session, setUsers, {
+            search: searchEntryOverwritten,
+            ordering: sorttype, student__location_group__in: regionsFilter,
             syndicus__id__gt: syndicusFilter, admin__id__gt: adminFilter, student__id__gt: studentFilter,
             student__is_super_student: superStudentFilter});
-    }, [session, selectedRegions, sorttype, userType]);
-
-
-    useEffect(() => {
-        const element = document.getElementById(styles.scroll_style);
-        if (element !== null) {
-            element.scrollTo({top: 0, behavior: 'smooth'});
-        }
-    }, [sorttype, selectedRegions]);
-
-    const filterUsers = (data: User[], search: string) => {
-        if (!search) {
-            return data;
-        } else {
-            search = search.toLowerCase();
-            return data.filter((d) => {
-                return (d.first_name.toLowerCase().replace(/ /g, '').includes(search) ||
-                    d.last_name.toLowerCase().replace(/ /g, '').includes(search));
-            });
-        }
     };
 
 
@@ -88,20 +87,16 @@ export default function UsersPage() {
         selectedUserType={userType}
         setSelectedUserType={setUserType}
         allBuildings={allBuildings ? allBuildings.data : []}
+        handleSearch={handleSearch}
     />;
 
     if (users) {
-        const filteredUsers: ApiData<User[]> = {
-            data: filterUsers(users.data, searchEntry),
-            status: users.status,
-            success: users.success,
-        };
 
         return (
 
             <>
                 <ListViewComponent
-                    listData={filteredUsers}
+                    listData={users}
                     setListData={setUsers}
                     locationGroups={locationGroups}
                     selectedRegions={selectedRegions}

--- a/frontend/src/containers/UsersPage.tsx
+++ b/frontend/src/containers/UsersPage.tsx
@@ -91,7 +91,6 @@ export default function UsersPage() {
     />;
 
     if (users) {
-
         return (
 
             <>

--- a/frontend/src/containers/UsersPage.tsx
+++ b/frontend/src/containers/UsersPage.tsx
@@ -1,7 +1,7 @@
 import ListViewComponent from '@/components/elements/ListViewElement/ListViewComponent';
 import UserElement from '@/components/elements/UserElement/UserElement';
 import {useSession} from 'next-auth/react';
-import {ApiData, getBuildingsList, getLocationGroupsList, getUsersList, useAuthenticatedApi} from '@/api/api';
+import {getBuildingsList, getLocationGroupsList, getUsersList, useAuthenticatedApi} from '@/api/api';
 import {Building, LocationGroup, User} from '@/api/models';
 import React, {useEffect, useState} from 'react';
 import UserTopBarComponent from '@/components/elements/ListViewElement/TopBarElements/UserTopBarComponent';


### PR DESCRIPTION
Almost all of the filtering and searching works with the backend now.
There are still some that don't yet work because the back end does not support them yet, but I figured it would be best to merge this already since it is stable and the filters that don't work just do nothing for now.
Filters that don't work yet are: routes (filtering when working with newest version routes), live routes (order by progress, filter active or done).
All the rest should work perfectly.

closes #215 