### PR TITLE
Endpoint for students to view schedule definitions

### DIFF
--- a/backend/drtrottoir/views/schedule_definition.py
+++ b/backend/drtrottoir/views/schedule_definition.py
@@ -9,6 +9,7 @@ from drtrottoir.models import (
 )
 from drtrottoir.permissions import (
     HasAssignmentForScheduleDefinition,
+    IsStudent,
     IsSuperstudentOrAdmin,
 )
 from drtrottoir.serializers import (
@@ -90,6 +91,7 @@ class ScheduleDefinitionViewSet(
         "retrieve": [permissions.IsAuthenticated, HasAssignmentForScheduleDefinition],
         "buildings": [permissions.IsAuthenticated, HasAssignmentForScheduleDefinition],
         "order": [permissions.IsAuthenticated, HasAssignmentForScheduleDefinition],
+        "assigned_to_me": [permissions.IsAuthenticated, IsStudent],
     }
 
     @action(detail=True)
@@ -171,6 +173,15 @@ SELECT t1.*
     ) t2
         ON t1.name = t2.name AND t1.version = t2.max_version
             """
+        )
+        serializer = ScheduleDefinitionSerializer(schedule_definitions, many=True)
+
+        return Response(serializer.data)
+
+    @action(detail=False)
+    def assigned_to_me(self, request):
+        schedule_definitions = self.filter_queryset(
+            self.get_queryset().filter(assignments__user=request.user)
         )
         serializer = ScheduleDefinitionSerializer(schedule_definitions, many=True)
 


### PR DESCRIPTION
This adds an endpoint that gives students access to the schedule definitions they have assignments for.

Closes #269 