### PR TITLE
Add my-schedule to superstudent and admin views on mobile

### DIFF
--- a/frontend/src/components/elements/NavbarElement/MobileNavbarComponent.tsx
+++ b/frontend/src/components/elements/NavbarElement/MobileNavbarComponent.tsx
@@ -37,8 +37,9 @@ const topButtonsAdmin = [
     {id: '2', text: 'Gebruikers', href: '/users', icon: PeopleAltRoundedIcon},
     {id: '3', text: 'Routes', href: '/routes', icon: RouteIcon},
     {id: '4', text: 'Gebouwen', href: '/buildings', icon: ApartmentRoundedIcon},
-    {id: '5', text: 'Account', href: '/profile', icon: PersonRoundedIcon},
-    {id: '6', text: 'Logout', href: '/logout', icon: LogoutRoundedIcon},
+    {id: '5', text: 'Mijn Planning', href: '/my-schedule', icon: DateRangeIcon},
+    {id: '6', text: 'Account', href: '/profile', icon: PersonRoundedIcon},
+    {id: '7', text: 'Logout', href: '/logout', icon: LogoutRoundedIcon},
 ];
 
 const botButtonsStudent = [


### PR DESCRIPTION
This feature already existed, but only for students. It should be possible for super students (in rare occasions) and admins (in very rare occasions) to also be assigned a schedule assignment (e.g. in case a student is sick), and so the my-schedule button is also needed for them. Because of how rare super students and admins get schedule assignments, I've only added a button to the top navbar.

Closes #302 