### PR TITLE
Filter schedule definitions by percentage done

### DIFF
--- a/backend/drtrottoir/serializers/schedule_assignment.py
+++ b/backend/drtrottoir/serializers/schedule_assignment.py
@@ -4,6 +4,11 @@ from drtrottoir.models import ScheduleAssignment
 
 
 class ScheduleAssignmentSerializer(serializers.ModelSerializer):
+    buildings_count = serializers.IntegerField(read_only=True)
+    buildings_done = serializers.IntegerField(read_only=True)
+    buildings_to_do = serializers.IntegerField(read_only=True)
+    buildings_percentage = serializers.IntegerField(read_only=True)
+
     class Meta:
         model = ScheduleAssignment
         fields = "__all__"

--- a/backend/drtrottoir/tests/test_schedule_assignment.py
+++ b/backend/drtrottoir/tests/test_schedule_assignment.py
@@ -126,7 +126,16 @@ def test_schedule_assignment_get_existing_returns_200() -> None:
     assert response.data["user"] == user.id
     assert date_equals(response.data["assigned_date"], str(assignment.assigned_date))
 
-    expected_fields = ["id", "assigned_date", "schedule_definition", "user"]
+    expected_fields = [
+        "id",
+        "assigned_date",
+        "schedule_definition",
+        "user",
+        "buildings_count",
+        "buildings_done",
+        "buildings_to_do",
+        "buildings_percentage",
+    ]
     assert sorted(expected_fields) == sorted(list(response.data.keys()))
 
 

--- a/backend/drtrottoir/views/schedule_assignment.py
+++ b/backend/drtrottoir/views/schedule_assignment.py
@@ -104,6 +104,7 @@ class ScheduleAssignmentViewSet(PermissionsByActionMixin, viewsets.ModelViewSet)
         "schedule_definition__name",
         "schedule_definition__location_group__name",
         "user__username",
+        "buildings_percentage",
     ]
 
     def get_queryset(self):

--- a/backend/drtrottoir/views/schedule_assignment.py
+++ b/backend/drtrottoir/views/schedule_assignment.py
@@ -1,5 +1,7 @@
 from typing import List
 
+import django_filters
+from django.db.models import Count, F
 from rest_framework import viewsets
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -13,6 +15,44 @@ from drtrottoir.permissions import (
 from drtrottoir.serializers import ScheduleAssignmentSerializer
 
 from .mixins import PermissionsByActionMixin
+
+
+class ScheduleAssignmentFilter(django_filters.FilterSet):
+    buildings_count = django_filters.NumberFilter()
+
+    buildings_to_do = django_filters.NumberFilter()
+    buildings_to_do__gt = django_filters.NumberFilter(
+        field_name="buildings_to_do", lookup_expr="gt"
+    )
+    buildings_to_do__lt = django_filters.NumberFilter(
+        field_name="buildings_to_do", lookup_expr="lt"
+    )
+
+    buildings_done = django_filters.NumberFilter()
+    buildings_done__gt = django_filters.NumberFilter(
+        field_name="buildings_done", lookup_expr="gt"
+    )
+    buildings_done__lt = django_filters.NumberFilter(
+        field_name="buildings_done", lookup_expr="lt"
+    )
+
+    buildings_percentage = django_filters.NumberFilter()
+    buildings_percentage__gt = django_filters.NumberFilter(
+        field_name="buildings_percentage", lookup_expr="gt"
+    )
+    buildings_percentage__lt = django_filters.NumberFilter(
+        field_name="buildings_percentage", lookup_expr="lt"
+    )
+
+    class Meta:
+        model = ScheduleAssignment
+
+        fields = {
+            "assigned_date": ("exact", "in", "gt", "lt"),
+            "schedule_definition": ("exact", "in"),
+            "user": ("exact", "in"),
+            "schedule_definition__location_group": ("exact", "in"),
+        }
 
 
 class ScheduleAssignmentViewSet(PermissionsByActionMixin, viewsets.ModelViewSet):
@@ -45,6 +85,7 @@ class ScheduleAssignmentViewSet(PermissionsByActionMixin, viewsets.ModelViewSet)
     """  # noqa
 
     serializer_class = ScheduleAssignmentSerializer
+    filterset_class = ScheduleAssignmentFilter
 
     permission_classes = [IsAuthenticated, IsSuperstudentOrAdmin]
     permission_classes_by_action = {
@@ -52,12 +93,6 @@ class ScheduleAssignmentViewSet(PermissionsByActionMixin, viewsets.ModelViewSet)
         "list": [IsAuthenticated, IsStudent | IsSuperstudentOrAdmin],
     }
 
-    filterset_fields = {
-        "assigned_date": ("exact", "in", "gt", "lt"),
-        "schedule_definition": ("exact", "in"),
-        "user": ("exact", "in"),
-        "schedule_definition__location_group": ("exact", "in"),
-    }
     search_fields: List[str] = [
         "schedule_definition__name",
         "user__username",
@@ -77,9 +112,19 @@ class ScheduleAssignmentViewSet(PermissionsByActionMixin, viewsets.ModelViewSet)
         regular users can only see their own.
         """
         if user_is_superstudent_or_admin(self.request.user):
-            return ScheduleAssignment.objects.all()
+            queryset = ScheduleAssignment.objects.all()
 
-        return ScheduleAssignment.objects.filter(user=self.request.user.id)
+        else:
+            queryset = ScheduleAssignment.objects.filter(user=self.request.user.id)
+
+        queryset = queryset.annotate(
+            buildings_count=Count("schedule_definition__buildings", distinct=True),
+            buildings_done=Count("work_entries__building", distinct=True),
+            buildings_to_do=F("buildings_count") - F("buildings_done"),
+            buildings_percentage=F("buildings_done") * 100 / F("buildings_count"),
+        )
+
+        return queryset
 
     def update(self, *args, **kwargs):
         schedule_assignment = self.get_object()

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -27,5 +27,9 @@ ignore_missing_imports = true
 module = "sendgrid.*"
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+module = "django_filters.*"
+ignore_missing_imports = true
+
 [tool.django-stubs]
 django_settings_module = "drtrottoir.settings"

--- a/frontend/src/api/models.ts
+++ b/frontend/src/api/models.ts
@@ -48,6 +48,10 @@ export type ScheduleAssignment = {
     assigned_date: string;
     schedule_definition: number;
     user: number;
+    buildings_count: number;
+    buildings_done: number;
+    buildings_to_do: number;
+    buildings_percentage: number;
 };
 
 export type ScheduleWorkEntry = {

--- a/frontend/src/components/elements/SchedulerElements/CustomCalendar/WeekComponent.tsx
+++ b/frontend/src/components/elements/SchedulerElements/CustomCalendar/WeekComponent.tsx
@@ -106,17 +106,29 @@ export default function WeekComponent(props: schedulerProps) {
                     date.setDate(props.start + scheduleAssignmentIndex);
                     date.setHours(date.getHours() + 2);
                     newTask = {
-                        id: -1, // will be ignored by django, but required to fit type
                         user: userId,
                         assigned_date: date.toISOString().split('T')[0],
                         schedule_definition: scheduleDefinitionIndex,
+
+                        // will be ignored by django, but required to fit type
+                        id: -1,
+                        buildings_count: 0,
+                        buildings_to_do: 0,
+                        buildings_done: 0,
+                        buildings_percentage: 0,
                     };
                 } else {
                     newTask = {
-                        id: -1, // will be ignored by django, but required to fit type
                         user: userId,
                         assigned_date: scheduleAssignmentIndex,
                         schedule_definition: scheduleDefinitionIndex,
+
+                        // will be ignored by django, but required to fit type
+                        id: -1,
+                        buildings_count: 0,
+                        buildings_to_do: 0,
+                        buildings_done: 0,
+                        buildings_percentage: 0,
                     };
                 }
 


### PR DESCRIPTION
This PR adds:

* `buildings_count`, `buildings_done`, `buildings_to_do` and `buildings_percentage` integer fields to a schedule assignment. All of them can be filtered exactly, e.g. `buildings_count=5`, and all but `buildings_count` can also be filtered using `__gt` and `__lt`. E.g. to list all schedule assignments that haven't finished yet, use `?buildings_to_do__gt=0`
* Filtering for all these fields, so to filter by percentage done, for lowest to highest, use `ordering=buildings_percentage`

Closes #255 